### PR TITLE
Bugfix: Improve error handling and add nil checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/joho/godotenv v1.5.1
 )
 
-require github.com/mattn/go-sqlite3 v1.14.28 // indirect
+require github.com/mattn/go-sqlite3 v1.14.28


### PR DESCRIPTION
- Enhanced error handling in Knovvu interactions in agent.go, adding nil/empty checks for responses to prevent panics.
- Updated LLM clients (Gemini and OpenAI) to retry on specific HTTP server-side errors (429, 500, 502, 503, 504).
- Added checks in LLM clients to handle cases where the API might return empty content, preventing silent errors during JSON unmarshalling.
- Ensured HTTP response bodies are closed promptly, especially during retry loops.
- Ran go mod tidy to update go.mod and go.sum.